### PR TITLE
Fix for rails 7.1 that deprecated_parameters_hash_equality

### DIFF
--- a/app/controllers/concerns/ransack_memory/concern.rb
+++ b/app/controllers/concerns/ransack_memory/concern.rb
@@ -42,7 +42,7 @@ module RansackMemory
       params[:per_page] = session["#{session_key_base}_per_page"].presence
 
       # set page number to 1 if filter has changed
-      if (params[::RansackMemory::Core.config[:param]].present? && session[:last_q_params] != params[::RansackMemory::Core.config[:param]]) || (params[:cancel_filter].present? && session["#{session_key_base}_page"] != params[:page])
+      if (params[::RansackMemory::Core.config[:param]].present? && session[:last_q_params] != params[::RansackMemory::Core.config[:param]].permit!.to_h) || (params[:cancel_filter].present? && session["#{session_key_base}_page"] != params[:page])
         params[:page] = nil
         session["#{session_key_base}_page"] = nil
       end


### PR DESCRIPTION
Since Rails 7.1 there is a new framework default deprecated_parameters_hash_equality.

We are no more able to compare Hash with ActionController::Parameters.

We need to convert the ActionController::Parameters to hash by doing permit! and calling to_h.