### PR TITLE
Refactor controller name to account for namespaced controllers

### DIFF
--- a/app/controllers/concerns/ransack_memory/concern.rb
+++ b/app/controllers/concerns/ransack_memory/concern.rb
@@ -6,7 +6,7 @@ module RansackMemory
       user_set_key_identifier = respond_to?(:set_session_key_identifier) ? send(:set_session_key_identifier) : nil
 
       session_key_identifier = ::RansackMemory::Core.config[:session_key_format]
-                                   .gsub('%controller_name%', controller_name)
+                                   .gsub('%controller_name%', controller_path.parameterize.underscore)
                                    .gsub('%action_name%', action_name)
                                    .gsub('%request_format%', request.format.symbol.to_s)
 


### PR DESCRIPTION
I suggest making this change to account for name spacing in controllers ie:
`PaymentsController` and `Admin::PaymentsController`
This prevents the filters being shared between controllers accidentally.
Hopefully this is useful to someone
Thanks!