### PR TITLE
Add support for turbo frames

### DIFF
--- a/app/controllers/concerns/ransack_memory/concern.rb
+++ b/app/controllers/concerns/ransack_memory/concern.rb
@@ -9,6 +9,7 @@ module RansackMemory
                                    .gsub('%controller_name%', controller_path.parameterize.underscore)
                                    .gsub('%action_name%', action_name)
                                    .gsub('%request_format%', request.format.symbol.to_s)
+                                   .gsub('%turbo_frame%', request.headers['Turbo-Frame'] || 'top')
 
       session_key_base = user_set_key_identifier.presence || "ranmemory_#{session_key_identifier}"
       session_key_base = "ranmemory_#{session_key_base}" unless session_key_base.starts_with?('ranmemory')

--- a/lib/generators/ransack_memory_generator.rb
+++ b/lib/generators/ransack_memory_generator.rb
@@ -5,7 +5,7 @@ if defined?(Rails)
     source_root(File.expand_path(File.dirname(__FILE__) + "/../templates/ransack_memory"))
     def copy_initializer
 
-      copy_file 'ransack_memory_template.rb', 'config/initializers/ransack_memory.rb'
+      template 'ransack_memory_template.rb', 'config/initializers/ransack_memory.rb'
     end
   end
 

--- a/lib/templates/ransack_memory/ransack_memory_template.rb
+++ b/lib/templates/ransack_memory/ransack_memory_template.rb
@@ -1,4 +1,19 @@
 RansackMemory::Core.config = {
-  param: :q, # this means the default Ransack param name for searching. You can change it
-  session_key_format: '%controller_name%_%action_name%_%request_format%' # this means how the key used to store the information to the session will be stored. Currently it interpolates request parameters. You can customize it and use these vars to build a key that fits your needs
+  # This means the default Ransack param name for searching. You can change it
+  param: :q,
+
+  # This means how the key used to store the information to the session
+  # will be stored. Currently it interpolates request parameters.
+  # You can customize it and use these vars to build a key that fits your needs
+  #
+  # Available variables are:
+  #   controller_name
+  #   action_name
+  #   request_format
+  #   turbo_frame
+<% if defined? Turbo -%>
+  session_key_format: '%controller_name%_%action_name%_%request_format%_%turbo_frame%'
+<% else -%>
+  session_key_format: '%controller_name%_%action_name%_%request_format%'
+<% end -%>
 }


### PR DESCRIPTION
Allow the session key to include the turbo frame id.

Also, the config generator detects if turbo-rails is present to include the turbo frame variable by default.